### PR TITLE
Skip TCPIP check in resource list

### DIFF
--- a/lecroydso/lecroyvisa.py
+++ b/lecroydso/lecroyvisa.py
@@ -31,7 +31,7 @@ class LeCroyVISA(DSOConnection):
 
         rm = pyvisa.ResourceManager()
         resources = rm.list_resources()
-        if connection_string not in resources:
+        if 'TCPIP' not in connection_string and connection_string not in resources:
             raise DSOConnectionError('LeCroyVISA connection failed, {}'.format(connection_string))
             self.connected = False
             return


### PR DESCRIPTION
Addresses Issue #6  to allow for tcpip connections.  Once pyvisa(-py) supports TCPIP discovery in its ResourceManager, the check can be added back such that we are not relying on an exception being thrown.